### PR TITLE
Support building upstream latest release from the website

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: links
-version: '2.15'
+adopt-info: links
 summary: Web browser running in text mode
 description: |
   Links is a text mode WWW browser, similar to Lynx. It displays tables,
@@ -19,7 +19,8 @@ apps:
 parts:
   links:
     plugin: make
-    source: http://links.twibright.com/download/links-$SNAPCRAFT_PROJECT_VERSION.tar.bz2
+    #source: Parsed at override-pull scriptlet
+    # https://salsa.debian.org/debian/links2/blob/master/debian/control
     build-packages:
       - gcc
       - libbz2-dev
@@ -38,9 +39,44 @@ parts:
       - libpcre3
       - liblz1
       - zlib1g
+
+    override-pull: |
+      set -o nounset
+
+      latest_release_version="$(
+        wget \
+          --output-document=- \
+          http://links.twibright.com/download \
+          2>/dev/null \
+          | grep \
+            --only-matching \
+            --extended-regexp \
+            'href="links-.*.tar.bz2"' \
+          | cut --delimiter='"' --fields=2 \
+          | sort --version-sort --reverse \
+          | head --lines=1 \
+          | cut --characters=7- \
+          | sed 's/.tar.bz2//'
+      )"
+
+      printf -- \
+        'override-pull: Setting snap version to %s.\n' \
+        "${latest_release_version}"
+      snapcraftctl set-version \
+        "${latest_release_version}"
+
+      latest_release_tarball="http://links.twibright.com/download/links-${latest_release_version}.tar.bz2"
+
+      wget \
+        --output-document=- \
+        "${latest_release_tarball}" \
+        | tar \
+          --bzip2 \
+          --extract \
+          --strip-components=1
+
     override-build: |
       ./configure \
-        --enable-javascript \
         --with-ssl \
         --without-svgalib \
         --without-x \


### PR DESCRIPTION
This patch implements override-pull scriptlet to parse and download the
latest release tarball from the upstream website automatically.

The javascript support has been dropped due to FTBFS:

```
../jsint.c:39:10: fatal error: struct.h: no such file or directory
 #include "struct.h"
```

and apparently no one else in the world<sup>[1]</sup> <sup>[2]</sup> has enable it.

[1]: https://src.fedoraproject.org/rpms/links/blob/master/f/links.spec
[2]: https://salsa.debian.org/debian/links2/blob/master/debian/rules

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>