### PR TITLE
Migrate to bases

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
 
 grade: stable
 confinement: strict
+base: core
 
 apps:
   links:
@@ -18,8 +19,7 @@ apps:
 
 parts:
   links:
-    plugin: make
-    #source: Parsed at override-pull scriptlet
+    plugin: nil
     # https://salsa.debian.org/debian/links2/blob/master/debian/control
     build-packages:
       - gcc


### PR DESCRIPTION
Update to the base syntax.

Replace the plugin to `nil` as we don't use it anyway and it requires `source` to be set.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>